### PR TITLE
chore: target .NET Framework 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    paths:
+      - '**.cs'
+      - '**.resx'
+      - 'SpawnEditor.csproj'
+      - 'SpawnEditor.sln'
+      - '.github/workflows/ci.yml'
+  pull_request:
+    paths:
+      - '**.cs'
+      - '**.resx'
+      - 'SpawnEditor.csproj'
+      - 'SpawnEditor.sln'
+      - '.github/workflows/ci.yml'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '7.0.x'
+      - name: Build
+        run: dotnet build SpawnEditor.sln

--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -26,7 +26,7 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
 
 //
 // In order to sign your assembly you must specify a key to use. Refer to the 

--- a/SpawnEditor.csproj
+++ b/SpawnEditor.csproj
@@ -1,175 +1,33 @@
-<VisualStudioProject>
-    <CSHARP
-        ProjectType = "Local"
-        ProductVersion = "7.10.3077"
-        SchemaVersion = "2.0"
-        ProjectGuid = "{F16E9EC5-19BF-408E-97BC-3F12C986CA67}"
-    >
-        <Build>
-            <Settings
-                ApplicationIcon = "App.ico"
-                AssemblyKeyContainerName = ""
-                AssemblyName = "SpawnEditor"
-                AssemblyOriginatorKeyFile = ""
-                DefaultClientScript = "JScript"
-                DefaultHTMLPageLayout = "Grid"
-                DefaultTargetSchema = "IE50"
-                DelaySign = "false"
-                OutputType = "WinExe"
-                PreBuildEvent = ""
-                PostBuildEvent = ""
-                RootNamespace = "SpawnEditor"
-                RunPostBuildEvent = "OnBuildSuccess"
-                StartupObject = ""
-            >
-                <Config
-                    Name = "Debug"
-                    AllowUnsafeBlocks = "false"
-                    BaseAddress = "285212672"
-                    CheckForOverflowUnderflow = "false"
-                    ConfigurationOverrideFile = ""
-                    DefineConstants = "DEBUG;TRACE"
-                    DocumentationFile = ""
-                    DebugSymbols = "true"
-                    FileAlignment = "4096"
-                    IncrementalBuild = "true"
-                    NoStdLib = "false"
-                    NoWarn = ""
-                    Optimize = "false"
-                    OutputPath = "bin\Debug\"
-                    RegisterForComInterop = "false"
-                    RemoveIntegerChecks = "false"
-                    TreatWarningsAsErrors = "false"
-                    WarningLevel = "4"
-                />
-                <Config
-                    Name = "Release"
-                    AllowUnsafeBlocks = "false"
-                    BaseAddress = "285212672"
-                    CheckForOverflowUnderflow = "false"
-                    ConfigurationOverrideFile = ""
-                    DefineConstants = "TRACE"
-                    DocumentationFile = ""
-                    DebugSymbols = "false"
-                    FileAlignment = "4096"
-                    IncrementalBuild = "false"
-                    NoStdLib = "false"
-                    NoWarn = ""
-                    Optimize = "true"
-                    OutputPath = "bin\Release\"
-                    RegisterForComInterop = "false"
-                    RemoveIntegerChecks = "false"
-                    TreatWarningsAsErrors = "false"
-                    WarningLevel = "4"
-                />
-            </Settings>
-            <References>
-                <Reference
-                    Name = "System"
-                    AssemblyName = "System"
-                    HintPath = "C:\WINNT\Microsoft.NET\Framework\v1.0.3705\System.dll"
-                />
-                <Reference
-                    Name = "System.Data"
-                    AssemblyName = "System.Data"
-                    HintPath = "C:\WINNT\Microsoft.NET\Framework\v1.0.3705\System.Data.dll"
-                />
-                <Reference
-                    Name = "System.Drawing"
-                    AssemblyName = "System.Drawing"
-                    HintPath = "C:\WINNT\Microsoft.NET\Framework\v1.0.3705\System.Drawing.dll"
-                />
-                <Reference
-                    Name = "System.Windows.Forms"
-                    AssemblyName = "System.Windows.Forms"
-                    HintPath = "C:\WINNT\Microsoft.NET\Framework\v1.0.3705\System.Windows.Forms.dll"
-                />
-                <Reference
-                    Name = "System.XML"
-                    AssemblyName = "System.Xml"
-                    HintPath = "C:\WINNT\Microsoft.NET\Framework\v1.0.3705\System.XML.dll"
-                />
-                <Reference
-                    Name = "stdole"
-                    Guid = "{00020430-0000-0000-C000-000000000046}"
-                    VersionMajor = "2"
-                    VersionMinor = "0"
-                    Lcid = "0"
-                    WrapperTool = "primary"
-                />
-                <Reference
-                    Name = "UOMAPLib"
-                    AssemblyName = "UOMAPLib"
-                    HintPath = "UOMAPLib.dll"
-                />
-                <Reference
-                    Name = "AxUOMAPLib"
-                    AssemblyName = "AxUOMAPLib"
-                    HintPath = "AxUOMAPLib.dll"
-                />
-            </References>
-        </Build>
-        <Files>
-            <Include>
-                <File
-                    RelPath = "Amount.cs"
-                    SubType = "Form"
-                    BuildAction = "Compile"
-                />
-                <File
-                    RelPath = "Amount.resx"
-                    DependentUpon = "Amount.cs"
-                    BuildAction = "EmbeddedResource"
-                />
-                <File
-                    RelPath = "App.ico"
-                    BuildAction = "Content"
-                />
-                <File
-                    RelPath = "Area.cs"
-                    SubType = "Form"
-                    BuildAction = "Compile"
-                />
-                <File
-                    RelPath = "Area.resx"
-                    DependentUpon = "Area.cs"
-                    BuildAction = "EmbeddedResource"
-                />
-                <File
-                    RelPath = "AssemblyInfo.cs"
-                    SubType = "Code"
-                    BuildAction = "Compile"
-                />
-                <File
-                    RelPath = "Changes.txt"
-                    BuildAction = "Content"
-                />
-                <File
-                    RelPath = "Configure.cs"
-                    SubType = "Form"
-                    BuildAction = "Compile"
-                />
-                <File
-                    RelPath = "Configure.resx"
-                    DependentUpon = "Configure.cs"
-                    BuildAction = "EmbeddedResource"
-                />
-                <File
-                    RelPath = "ReadMe.htm"
-                    BuildAction = "Content"
-                />
-                <File
-                    RelPath = "SpawnEditor.cs"
-                    SubType = "Form"
-                    BuildAction = "Compile"
-                />
-                <File
-                    RelPath = "SpawnEditor.resx"
-                    DependentUpon = "SpawnEditor.cs"
-                    BuildAction = "EmbeddedResource"
-                />
-            </Include>
-        </Files>
-    </CSHARP>
-</VisualStudioProject>
-
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+	    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	    <OutputType>WinExe</OutputType>
+	    <TargetFramework>net40</TargetFramework>
+	    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+	    <RootNamespace>SpawnEditor</RootNamespace>
+	    <AssemblyName>SpawnEditor</AssemblyName>
+	    <ApplicationIcon>App.ico</ApplicationIcon>
+	</PropertyGroup>
+	<ItemGroup>
+	    <Reference Include="UOMAPLib">
+	    	<HintPath>UOMAPLib.dll</HintPath>
+	    </Reference>
+	    <Reference Include="AxUOMAPLib">
+	    	<HintPath>AxUOMAPLib.dll</HintPath>
+	    </Reference>
+	    <Reference Include="stdole" />
+	    <Reference Include="System.Windows.Forms" />
+	    <Reference Include="System.Drawing" />
+	</ItemGroup>
+	<ItemGroup>
+	    <Content Include="Changes.txt" />
+	    <Content Include="ReadMe.htm" />
+	    <Content Include="App.ico" />
+	</ItemGroup>
+	<ItemGroup>
+	    <Compile Remove="XmlSpawner.cs" />
+	    <Compile Remove="SpawnEditorCommands.cs" />
+	    <None Include="XmlSpawner.cs" />
+	    <None Include="SpawnEditorCommands.cs" />
+	</ItemGroup>
+</Project>

--- a/SpawnEditor.sln
+++ b/SpawnEditor.sln
@@ -1,21 +1,22 @@
-Microsoft Visual Studio Solution File, Format Version 8.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpawnEditor", "SpawnEditor.csproj", "{F16E9EC5-19BF-408E-97BC-3F12C986CA67}"
-	ProjectSection(ProjectDependencies) = postProject
-	EndProjectSection
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpawnEditor", "SpawnEditor.csproj", "{23D03CA5-05C8-40B4-804E-37F805A681C6}"
 EndProject
 Global
-	GlobalSection(SolutionConfiguration) = preSolution
-		Debug = Debug
-		Release = Release
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfiguration) = postSolution
-		{F16E9EC5-19BF-408E-97BC-3F12C986CA67}.Debug.ActiveCfg = Debug|.NET
-		{F16E9EC5-19BF-408E-97BC-3F12C986CA67}.Debug.Build.0 = Debug|.NET
-		{F16E9EC5-19BF-408E-97BC-3F12C986CA67}.Release.ActiveCfg = Release|.NET
-		{F16E9EC5-19BF-408E-97BC-3F12C986CA67}.Release.Build.0 = Release|.NET
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-	EndGlobalSection
-	GlobalSection(ExtensibilityAddIns) = postSolution
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{23D03CA5-05C8-40B4-804E-37F805A681C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23D03CA5-05C8-40B4-804E-37F805A681C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23D03CA5-05C8-40B4-804E-37F805A681C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23D03CA5-05C8-40B4-804E-37F805A681C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- update project references to .NET Framework 4.0 paths
- migrate project file to SDK-style MSBuild format targeting .NET Framework 4.0
- regenerate solution file and enable Windows targeting
- drop pre-generated `.resources` and verification script; rely on `.resx` files
- simplify CI workflow to build the solution

## Testing
- `dotnet build SpawnEditor.sln` *(fails: Non-string resources require the System.Resources.Extensions assembly)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e837d254832984ea66faa47f681e