### PR TITLE
Use install script for .NET 6 in CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'
+      - name: Install .NET 6
+        run: bash ./install-net6
       - run: dotnet build SpawnEditor.sln

--- a/install-net6
+++ b/install-net6
@@ -4,4 +4,4 @@ sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get update; \
   sudo apt-get install -y apt-transport-https && \
   sudo apt-get update && \
-  sudo apt-get install -y dotnet-sdk-5.0
+  sudo apt-get install -y dotnet-sdk-6.0


### PR DESCRIPTION
## Summary
- fix `install-net6` to install .NET 6 SDK
- update Linux workflow to run the install script before building

## Testing
- `bash -n install-net6`
- `dotnet build SpawnEditor.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bab6939e788329a443bdbb64ccb5cb