### PR TITLE
Fix dotnet workflow to run on Windows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,9 +7,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install .NET 6
-        run: bash ./install-net6
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '6.0.x'
       - run: dotnet build SpawnEditor.sln


### PR DESCRIPTION
## Summary
- run .NET workflow on windows-latest
- install .NET 6 via actions/setup-dotnet

## Testing
- `dotnet build SpawnEditor.sln` *(fails: Windows is required to build Windows desktop applications)*

------
https://chatgpt.com/codex/tasks/task_e_68bab8426ab083299801c24d1d536544