### PR TITLE
Fix Windows workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,6 @@ name: Windows Build
 
 on:
   push:
-    branches: [ master ]
   pull_request:
 
 jobs:
@@ -10,5 +9,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
       - uses: microsoft/setup-msbuild@v2
-      - run: .\install-dotnet.ps1
+      - name: Install Windows Desktop workload
+        run: dotnet workload install windowsdesktop
+      - run: dotnet build SpawnEditor.sln

--- a/todo.md
+++ b/todo.md
@@ -17,7 +17,7 @@
 - [ ] Introduce continuous integration
   - [x] Create a GitHub Actions workflow to run `dotnet build`.
   - [x] Build on Windows runners.
-  - Next: Ensure workflow passes once project builds successfully.
+  - Next: Verify Windows workflow passes after adding Windows Desktop workload installation.
 - [ ] Verify static tile rendering accuracy across the entire map (elevations, hues).
 - [ ] Profile large map rendering for performance improvements.
 - [ ] Improve developer documentation


### PR DESCRIPTION
## Summary
- ensure Windows workflow sets up .NET 8 and installs Windows Desktop workload before building

## Testing
- `dotnet build SpawnEditor.sln` *(fails: Could not resolve SDK "Microsoft.NET.Sdk.WindowsDesktop". The SDK 'Microsoft.NET.Sdk.WindowsDesktop' specified could not be found.)*


------
https://chatgpt.com/codex/tasks/task_e_68bae38863848329a053dc6031574824